### PR TITLE
Lint with Flake8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Run pytest
+name: Run tests
 
 on: [push]
 
@@ -17,7 +17,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pip install pytest
         pytest

--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,4 @@
-import time
-import sys
 import tweepy
-from pprint import pprint
 from pandas import Timestamp
 from sentry_sdk import init as sentry_init
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ tweepy==3.8.0
 flask==1.1.1
 pandas==1.0.1
 sentry-sdk==0.14.2
+flake8==3.7.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ tweepy==3.8.0
 flask==1.1.1
 pandas==1.0.1
 sentry-sdk==0.14.2
+pytest==5.3.5
 flake8==3.7.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 127

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,4 +1,5 @@
 from bot import LOCAL_DEVELOPMENT
 
+
 def test_local_development():
-    assert LOCAL_DEVELOPMENT == False
+    assert not LOCAL_DEVELOPMENT

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,18 +1,20 @@
 from utils import average_interp, average_interp_timeseries, get_timeseries_coverage
 import pandas as pd
 
+
 def test_average_interp():
-    x = [0,2,4]
-    y = [0,4,2]
+    x = [0, 2, 4]
+    y = [0, 4, 2]
 
     # averaging over the observed interval
-    assert average_interp(y,x,0,4) == 10.0/4
+    assert average_interp(y, x, 0, 4) == 10.0/4
 
     # averaging over a narrower interval than observed
     assert average_interp(y, x, 1, 3) == 6.5/2
 
     # averaging over a wider interval than observed
     assert average_interp(y, x, -1, 5) == 12/6
+
 
 def test_average_interp_timeseries():
     now = pd.Timestamp.utcnow()
@@ -23,6 +25,7 @@ def test_average_interp_timeseries():
     t0 = now - pd.Timedelta(1, 'h')
     t1 = now + pd.Timedelta(5, 'h')
     assert average_interp_timeseries(temps, t0, t1) == 12/6
+
 
 def test_get_timeseries_coverage():
     now = pd.Timestamp.utcnow()

--- a/tweets.py
+++ b/tweets.py
@@ -274,7 +274,7 @@ def get_intervals(end_time, timedelta, start_year):
         # For Feb 29, replacing with a non-leap year will raise an error, just ignore those years
         try:
             end = end_time.replace(year=year)
-        except: # noqa
+        except ValueError:
             continue
         start = end - timedelta
         yield pd.Interval(start, end, closed='left')

--- a/tweets.py
+++ b/tweets.py
@@ -10,11 +10,21 @@ logging.getLogger().setLevel(logging.INFO)
 
 DATA_URL = 'https://www.istheweatherweird.com/istheweatherweird-data-hourly'
 STATIONS_URL = '{}/csv/stations.csv'.format(DATA_URL)
-MIN_COVERAGE= pd.Timedelta(4, 'h')
+MIN_COVERAGE = pd.Timedelta(4, 'h')
+
 
 def get_tweets(place):
     # UTC values for 6pm local time yesterday - 6pm local time today
-    end_time = pd.Timestamp.today(tz=place['TZ']).replace(hour=18).floor(freq='h').tz_convert(tz='UTC')
+    end_time = pd.Timestamp.today(
+        tz=place['TZ']
+    ).replace(
+        hour=18
+    ).floor(
+        freq='h'
+    ).tz_convert(
+        tz='UTC'
+    )
+
     start_time = end_time - pd.Timedelta(days=1)
 
     tweets = []

--- a/tweets.py
+++ b/tweets.py
@@ -54,7 +54,7 @@ def get_place(city):
 
 
 def get_observations(place, start_time, end_time):
-    nws_request_url ='https://api.weather.gov/stations/{}/observations'.format(
+    nws_request_url = 'https://api.weather.gov/stations/{}/observations'.format(
         place['ICAO']
     )
     params = {
@@ -67,7 +67,7 @@ def get_observations(place, start_time, end_time):
         timestamps = [obs['properties']['timestamp']
                       for obs in response_json['features']]
         temps = [obs['properties']['temperature']['value']
-                      for obs in response_json['features']]
+                 for obs in response_json['features']]
         observations = pd.Series(temps, index=pd.DatetimeIndex(timestamps))
     except KeyError:
         observations = pd.Series()
@@ -151,7 +151,7 @@ def write_tweet(place, start_time, end_time, timespan):
         ['warmer', 'warmest']
     ]
 
-    emoji_list = ['❄️','🔥']
+    emoji_list = ['❄️', '🔥']
 
     weirdness = weirdness_levels[weirdness_level]
     comparison = comparisons[warm_bool][(weirdness_level == 3)]
@@ -185,11 +185,11 @@ def write_sentences(sentence_dict, timespan):
         )
 
         if not sentence_dict['record']:
-            sentence2 = 'It was {observed_temp}ºF on average, {comparison} than {percent_relative}% of {month} {day} temperatures on record.'.format(
+            sentence2 = 'It was {observed_temp}ºF on average, {comparison} than {percent_relative}% of {month} {day} temperatures on record.'.format( # noqa
                 **sentence_dict
             )
         else:
-            sentence2 = 'It was {observed_temp}ºF on average, the {comparison} {month} {day} temperature on record.'.format(
+            sentence2 = 'It was {observed_temp}ºF on average, the {comparison} {month} {day} temperature on record.'.format( # noqa
                 **sentence_dict
             )
 
@@ -199,11 +199,11 @@ def write_sentences(sentence_dict, timespan):
         )
 
         if not sentence_dict['record']:
-            sentence2 = '{emoji}It was {observed_temp}ºF on average, {comparison} than {percent_relative}% of weeks ending {month} {day} on record.'.format(
+            sentence2 = '{emoji}It was {observed_temp}ºF on average, {comparison} than {percent_relative}% of weeks ending {month} {day} on record.'.format( # noqa
                 **sentence_dict
             )
         else:
-            sentence2 = '{emoji}It was {observed_temp}ºF on average, the {comparison} week ending {month} {day} on record.'.format(
+            sentence2 = '{emoji}It was {observed_temp}ºF on average, the {comparison} week ending {month} {day} on record.'.format( # noqa
                 **sentence_dict
             )
 
@@ -274,7 +274,7 @@ def get_intervals(end_time, timedelta, start_year):
         # For Feb 29, replacing with a non-leap year will raise an error, just ignore those years
         try:
             end = end_time.replace(year=year)
-        except:
+        except: # noqa
             continue
         start = end - timedelta
         yield pd.Interval(start, end, closed='left')
@@ -285,6 +285,13 @@ def get_unique_month_days(interval_index):
     For an interval index get a list of unique month-days
     Returns: a DataFrame with columns month and day
     """
-    dates = pd.concat([pd.Series(pd.date_range(i.left, i.right)) for i in interval_index])
-    month_days = pd.DataFrame({'month':dates.dt.month, 'day':dates.dt.day}).drop_duplicates()
+    dates = pd.concat(
+        [pd.Series(pd.date_range(i.left, i.right)) for i in interval_index]
+    )
+    month_days = pd.DataFrame(
+        {
+            'month': dates.dt.month,
+            'day': dates.dt.day
+        }
+    ).drop_duplicates()
     return month_days

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,8 @@
-import requests
-import csv
 import numpy as np
 import pandas as pd
 
 UNIX_TIME_START = pd.Timestamp(0, tz='UTC')
+
 
 def average_interp(y, x, x0, x1):
     """
@@ -22,7 +21,7 @@ def average_interp(y, x, x0, x1):
         3. Divide by (x1 - x0) to get an interpolated average
     """
     if len(y) != len(x):
-        raise ValueErrror("y and x should have same length")
+        raise ValueError("y and x should have same length")
     if x1 <= x0:
         raise ValueError("x1 should be greater than x0")
     if len(x) != len(np.unique(x)):


### PR DESCRIPTION
Closes #30. This PR brings the repo into compliance with Flake8 styles, which helps us stick to Python best practices, avoid importing anything we don't need, and will make this repo easier to maintain.