### PR TITLE
Add simple test_get_tweets

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ To get started, run the following from your terminal:
 
   If successful, you'll see generated tweets in the terminal.
 
+To run tests manually:
+
+`docker-compose run --rm app pytest`
+
 ## Setting up a bot for a new location
 
 Follow these steps to start a Twitter bot for one of the locations in the [stations spreadsheet](https://github.com/istheweatherweird/istheweatherweird-data-hourly/blob/master/csv/stations.csv):

--- a/bot.py
+++ b/bot.py
@@ -29,7 +29,10 @@ for city in cities:
         # ACCESS_KEY = globals()['{}_ACCESS_KEY'.format(icao)]
         # ACCESS_SECRET = globals()['{}_ACCESS_SECRET'.format(icao)]
 
-        print(get_tweets(place))
+        # UTC value for the current hour
+        end_time = Timestamp.now(tz='UTC').floor(freq='h')
+
+        print(get_tweets(place, end_time))
 
     else:
         from os import environ
@@ -46,6 +49,17 @@ for city in cities:
                 "make sure LOCAL_DEVELOPMENT=True."
             )
 
+        # UTC value for 6pm today
+        end_time = Timestamp.today(
+            tz=place['TZ']
+        ).replace(
+            hour=18
+        ).floor(
+            freq='h'
+        ).tz_convert(
+            tz='UTC'
+        )
+
     if current_time.hour == 18:
         # check if 6pm <= current local time < 7pm
         # this is intended to run every hour through the Heroku scheduler
@@ -54,7 +68,7 @@ for city in cities:
             auth.set_access_token(ACCESS_KEY, ACCESS_SECRET)
             api = tweepy.API(auth)
 
-            tweets = get_tweets(place)
+            tweets = get_tweets(place, end_time)
             for tweet in tweets:
                 if tweet:
                     api.update_status(tweet)

--- a/bot.py
+++ b/bot.py
@@ -56,6 +56,7 @@ for city in cities:
 
             tweets = get_tweets(place)
             for tweet in tweets:
-                api.update_status(tweet)
+                if tweet:
+                    api.update_status(tweet)
         except (tweepy.error.TweepError, NameError) as e:
             print('\nNot posted to Twitter!\n\nError: {}\n'.format(e))

--- a/tests/test_tweets.py
+++ b/tests/test_tweets.py
@@ -1,3 +1,5 @@
+from pandas import Timestamp
+
 from bot import LOCAL_DEVELOPMENT
 from tweets import get_place, get_tweets
 

--- a/tests/test_tweets.py
+++ b/tests/test_tweets.py
@@ -4,5 +4,6 @@ from tweets import get_place, get_tweets
 
 def test_get_tweets():
     place = get_place('Chicago')
-    tweets = get_tweets(place)
+    end_time = Timestamp.now(tz='UTC').floor(freq='h')
+    tweets = get_tweets(place, end_time)
     assert len(tweets) > 0

--- a/tests/test_tweets.py
+++ b/tests/test_tweets.py
@@ -1,0 +1,8 @@
+from bot import LOCAL_DEVELOPMENT
+from tweets import get_place, get_tweets
+
+
+def test_get_tweets():
+    place = get_place('Chicago')
+    tweets = get_tweets(place)
+    assert len(tweets) > 0

--- a/tweets.py
+++ b/tweets.py
@@ -13,18 +13,7 @@ STATIONS_URL = '{}/csv/stations.csv'.format(DATA_URL)
 MIN_COVERAGE = pd.Timedelta(4, 'h')
 
 
-def get_tweets(place):
-    # UTC values for 6pm local time yesterday - 6pm local time today
-    end_time = pd.Timestamp.today(
-        tz=place['TZ']
-    ).replace(
-        hour=18
-    ).floor(
-        freq='h'
-    ).tz_convert(
-        tz='UTC'
-    )
-
+def get_tweets(place, end_time):
     start_time = end_time - pd.Timedelta(days=1)
 
     tweets = []

--- a/tweets.py
+++ b/tweets.py
@@ -30,8 +30,7 @@ def get_tweets(place):
     tweets = []
     tweet = write_tweet(place, start_time, end_time, timespan='day')
 
-    if tweet:
-        tweets += [tweet]
+    tweets += [tweet]
 
     # If it's Sunday, tweet a weekly recap
     if end_time.tz_convert(tz=place['TZ']).day_name() == 'Sunday':
@@ -111,6 +110,7 @@ def write_tweet(place, start_time, end_time, timespan):
         observed_temp = get_observed_temp(place, start_time, end_time)
     except ValueError as e:
         capture_exception(e)
+        print(e)
         return
 
     historical_temps = get_historical_temps(place, start_time, end_time)


### PR DESCRIPTION
Also prints Sentry errors to console for local dev! @potash does this cover what you had in mind? If an error is raised for `Insufficient observational coverage` the tweet will return as `None`, which will still be counted as a list item but not accepted by `tweepy` as a tweet.