### PR TITLE
Bug fix: Handle missing temp observations

### DIFF
--- a/tests/test_tweets.py
+++ b/tests/test_tweets.py
@@ -1,9 +1,11 @@
 from pandas import Timestamp
 from tweets import get_place, get_tweets
+from bot import cities
 
 
 def test_get_tweets():
-    place = get_place('Chicago')
-    end_time = Timestamp.now(tz='UTC').floor(freq='h')
-    tweets = get_tweets(place, end_time)
-    assert len(tweets) > 0
+    for city in cities:
+        place = get_place(city)
+        end_time = Timestamp.now(tz='UTC').floor(freq='h')
+        tweets = get_tweets(place, end_time)
+        assert len(tweets) > 0

--- a/tests/test_tweets.py
+++ b/tests/test_tweets.py
@@ -1,6 +1,4 @@
 from pandas import Timestamp
-
-from bot import LOCAL_DEVELOPMENT
 from tweets import get_place, get_tweets
 
 

--- a/tweets.py
+++ b/tweets.py
@@ -15,9 +15,8 @@ MIN_COVERAGE = pd.Timedelta(4, 'h')
 DAY = pd.Timedelta(1, 'D')
 WEEK = pd.Timedelta(7, 'D')
 
-def get_tweets(place, end_time):
-    start_time = end_time - pd.Timedelta(days=1)
 
+def get_tweets(place, end_time):
     tweets = []
     tweet = write_tweet(place, end_time, DAY)
 
@@ -54,9 +53,13 @@ def get_observations(place, start_time, end_time):
 
     try:
         timestamps = [obs['properties']['timestamp']
-                      for obs in response_json['features']]
+                      for obs in response_json['features']
+                      if obs['properties']['temperature']['value']
+                      ]
         temps = [obs['properties']['temperature']['value']
-                 for obs in response_json['features']]
+                 for obs in response_json['features']
+                 if obs['properties']['temperature']['value']
+                 ]
         observations = pd.Series(temps, index=pd.DatetimeIndex(timestamps))
     except KeyError:
         observations = pd.Series()
@@ -303,6 +306,7 @@ def get_unique_month_days(interval_index):
         }
     ).drop_duplicates()
     return month_days
+
 
 def check_timeseries_coverage(timeseries, start_time, end_time, raise_error):
     """


### PR DESCRIPTION
When when the bot tried to tweet for NYC, it ran into [this error](https://sentry.io/organizations/itww-chicago/issues/1558726173/?project=4081958&query=is%3Aunresolved): 

```
ValueError tweets in write_tweet 
cannot convert float NaN to integer
```

After a little digging I realized that for one of the observations returned in the json from our NWS API call had a temp value of `None`, which was tripping this up. I put in a check here to make sure we only look at NWS temp values with a non-null value. 